### PR TITLE
feat: Use COPY --chmod to make default venv universally writeable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,7 @@ RUN apt-get -qq -y update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user "docker" with uid 1000
+# and universal directory /work
 RUN adduser \
       --shell /bin/bash \
       --gecos "default user" \
@@ -85,6 +86,7 @@ RUN adduser \
     chown -R docker /home/docker/work && \
     mkdir /work && \
     chown -R docker /work && \
+    chmod -R 777 /work && \
     printf '\nexport PATH=/usr/local/venv/bin:"${PATH}"\n' >> /root/.bashrc && \
     cp /root/.bashrc /etc/.bashrc && \
     echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ ENV PATH=/usr/local/venv/bin:"${PATH}"
 
 # Install any packages needed by default user
 RUN apt-get -qq -y update && \
-    apt-get -qq -y install \
+    apt-get -qq -y install --no-install-recommends \
       gcc \
       g++ \
       wget \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,9 @@ RUN apt-get -qq -y update && \
       g++ \
       wget \
       curl \
-      git && \
+      git \
+      vim \
+      emacs && \
     apt-get -y autoclean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/*
@@ -87,7 +89,7 @@ RUN adduser \
     cp /root/.bashrc /etc/.bashrc && \
     echo 'if [ -f /etc/.bashrc ]; then . /etc/.bashrc; fi' >> /etc/profile
 
-COPY --from=builder --chown=docker /usr/local/venv /usr/local/venv
+COPY --from=builder --chown=docker --chmod=777 /usr/local/venv /usr/local/venv
 
 USER docker
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: image
 
 image:
 	docker pull python:3.10-slim-bullseye
-	docker build \
+	docker buildx build \
 	--file Dockerfile \
 	--build-arg BASE_IMAGE=python:3.10-slim-bullseye \
 	--tag matthewfeickert/docker-python-template:latest \

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ run_default:
 		--rm \
 		-ti \
 		--user $(shell id -u $(USER)):$(shell id -g $(USER)) \
-		--volume $(shell pwd):/work \
+		--volume $(shell pwd):/home/docker/work \
 		matthewfeickert/docker-python-template:latest \
 		/bin/bash
 
@@ -25,7 +25,7 @@ run_non_default:
 		--rm \
 		-ti \
 		--user 2000:2000 \
-		--volume $(shell pwd):/work \
+		--volume $(shell pwd):/home/docker/work \
 		--workdir /work \
 		matthewfeickert/docker-python-template:latest \
 		/bin/bash


### PR DESCRIPTION
Resolves #2 

```
* Use Docker COPY --chmod option to make the default Python virtual environment
  writeable by any user with --chmod=777.
* Use docker buildx to build to use --chmod.
* Make directory /work universally read and writeable.
* Update mount points to /home/docker/work to avoid making /work unwriteable
  by mounting into it.
* Add vim and emacs.
```